### PR TITLE
Fix `Time.local` instead of `Time.now`

### DIFF
--- a/src/build.cr
+++ b/src/build.cr
@@ -84,4 +84,4 @@ File.open("#{output_dir}/slides.html", "w") do |file|
   p.to_s(file)
 end
 
-puts "ok (#{Time.now})"
+puts "ok (#{Time.local})"


### PR DESCRIPTION
Use `Time.local` instead of `Time.now` see https://github.com/crystal-lang/crystal/pull/7586
